### PR TITLE
Update the service bus sample to work with sb API changes

### DIFF
--- a/samples/servicebus-queue/consumer/main.go
+++ b/samples/servicebus-queue/consumer/main.go
@@ -29,26 +29,25 @@ func main() {
 	}
 
 	fmt.Println("setting up listener")
-	listenHandle, err := q.Receive(context.Background(),
-		func(ctx context.Context, msg *servicebus.Message) servicebus.DispositionAction {
-			fmt.Println("received message: ", string(msg.Data))
+	var messageHandler servicebus.HandlerFunc = func(ctx context.Context, msg *servicebus.Message) servicebus.DispositionAction {
+		fmt.Println("received message: ", string(msg.Data))
 
-			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
-			defer cancel()
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
 
-			qe, err := qm.Get(ctx, queueName)
-			if err != nil {
-				fmt.Println("create manager created error: ", err)
-			}
-			fmt.Println("number message left: ", *qe.MessageCount)
-			return msg.Complete()
-		})
+		qe, err := qm.Get(ctx, queueName)
+		if err != nil {
+			fmt.Println("create manager created error: ", err)
+		}
+		fmt.Println("number message left: ", *qe.MessageCount)
+		return msg.Complete()
+	}
+
+	err = q.Receive(context.Background(), messageHandler)
 	if err != nil {
 		// handle queue listener creation err
 		fmt.Println("listener: ", err)
 	}
-	// Close the listener handle for the Service Bus Queue
-	defer listenHandle.Close(context.Background())
 
 	fmt.Println("listening...")
 

--- a/samples/servicebus-queue/readme.md
+++ b/samples/servicebus-queue/readme.md
@@ -23,7 +23,7 @@ Prerequisites:
 - provisioned an [AKS Cluster](https://docs.microsoft.com/en-us/azure/aks/kubernetes-walkthrough)
 - your `kubeconfig` points to your cluster.  
 - [Metric Server deployed](https://github.com/kubernetes-incubator/metrics-server#deployment) to your cluster ([aks does not come with it deployed](https://github.com/Azure/AKS/issues/318)). Validate by running `kubectl get --raw "/apis/metrics.k8s.io/v1beta1/nodes" | jq .`
-- [helm](https://docs.helm.sh/using_helm/#quickstart-guide) or install on [helm on aks](https://docs.microsoft.com/en-us/azure/aks/kubernetes-helm)
+- install [helm on aks](https://docs.microsoft.com/en-us/azure/aks/kubernetes-helm)
 
 Get this repository and cd to this folder (on your GOPATH):
 
@@ -133,7 +133,7 @@ helm install --name sample-release ../../charts/azure-k8s-metrics-adapter --name
 >Note: if you used a Service Principal you will need the deployment with a service principal configured and a secret deployed with the service principal values 
 >
 >```
->helm install --name sample-release ../../charts/azure-k8s-metrics-adapter --namespace custom-metrics --set >azureAuthentication.method=clientSecret --set azureAuthentication.tenantID=<your tenantid> --set >azureAuthentication.clientID=<your clientID> --set azureAuthentication.clientSecret=<your clientSecret> --set >azureAuthentication.createSecret=true`
+>helm install --name sample-release ../../charts/azure-k8s-metrics-adapter --namespace custom-metrics --set azureAuthentication.method=clientSecret --set azureAuthentication.tenantID=<your tenantid> --set azureAuthentication.clientID=<your clientID> --set azureAuthentication.clientSecret=<your clientSecret> --set azureAuthentication.createSecret=true`
 >```
 
 > Note: if you used [Azure AD Pod Identity](../../README.md#using-azure-ad-pod-identity) you need to use the specific adapter template file that declares the Azure Identity Binding on [Line 49](../../deploy/adapter-aad-pod-identity.yaml#L49) and [Line 61](../../deploy/adapter-aad-pod-identity.yaml#L61).

--- a/samples/servicebus-queue/readme.md
+++ b/samples/servicebus-queue/readme.md
@@ -23,7 +23,7 @@ Prerequisites:
 - provisioned an [AKS Cluster](https://docs.microsoft.com/en-us/azure/aks/kubernetes-walkthrough)
 - your `kubeconfig` points to your cluster.  
 - [Metric Server deployed](https://github.com/kubernetes-incubator/metrics-server#deployment) to your cluster ([aks does not come with it deployed](https://github.com/Azure/AKS/issues/318)). Validate by running `kubectl get --raw "/apis/metrics.k8s.io/v1beta1/nodes" | jq .`
-- install [helm on aks](https://docs.microsoft.com/en-us/azure/aks/kubernetes-helm)
+- [helm](https://docs.helm.sh/using_helm/#quickstart-guide) or install [helm on aks](https://docs.microsoft.com/en-us/azure/aks/kubernetes-helm) (If you have RBAC enabled, you will need to configure permissions as outlined in the second link)
 
 Get this repository and cd to this folder (on your GOPATH):
 


### PR DESCRIPTION
Changes to consumer/main.go in the service bus sample to accomodate changes in the service bus API. Switches an anonymous function to a named, typed function to align with correct function type signature. Removes the listenHandle var as it is no longer returned by the SB API.