### PR TITLE
Make AppInsights Timespan & Request Interval Configurable

### DIFF
--- a/pkg/azure/appinsights/appinsights.go
+++ b/pkg/azure/appinsights/appinsights.go
@@ -56,6 +56,7 @@ func (c appinsightsClient) GetCustomMetric(request MetricRequest) (float64, erro
 	// this seems to be the best way to get the closest average rate at time of request
 	// any smaller time intervals and the values come back null
 	// TODO make this configurable?
+	// Please make this configurable.
 	request.Timespan = "PT5M"
 	request.Interval = "PT30S"
 


### PR DESCRIPTION
Please make request.Timespan & request.Interval configurable for end users. Through a helm install param or a yaml file or something like that.

I have a scenario where we are unable to collect metrics because the metrics interval specified above is too small.