### PR TITLE
Provide Docker Hub bot to post PR updates

### DIFF
--- a/deploy/bots/docker-hub/azuredeploy.json
+++ b/deploy/bots/docker-hub/azuredeploy.json
@@ -201,13 +201,13 @@
             }
         },
         {
-            "name": "Scraper CI Bot - Docker Hub Integration Run Failed",
+            "name": "Azure Kubernetes Metrics Adapter - Docker Hub Integration Run Failed",
             "type": "Microsoft.Insights/metricAlerts",
             "location": "global",
             "apiVersion": "2018-03-01",
             "tags": {},
             "properties": {
-                "description": "Scraper CI Bot - Docker Hub integration failed to run and post a comment on the pull request in GitHub",
+                "description": "Azure Kubernetes Metrics Adapter - Docker Hub integration failed to run and post a comment on the pull request in GitHub",
                 "severity": 3,
                 "enabled": true,
                 "scopes": [
@@ -240,13 +240,13 @@
             ]
         },
         {
-            "name": "Scraper CI Bot - Docker Hub Integration Trigger Failed",
+            "name": "Azure Kubernetes Metrics Adapter - Docker Hub Integration Trigger Failed",
             "type": "Microsoft.Insights/metricAlerts",
             "location": "global",
             "apiVersion": "2018-03-01",
             "tags": {},
             "properties": {
-                "description": "Scraper CI Bot - Docker Hub integration failed to be triggered due to an issue",
+                "description": "Azure Kubernetes Metrics Adapter - Docker Hub integration failed to be triggered due to an issue",
                 "severity": 3,
                 "enabled": true,
                 "scopes": [

--- a/deploy/bots/docker-hub/azuredeploy.json
+++ b/deploy/bots/docker-hub/azuredeploy.json
@@ -1,0 +1,282 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "LogicApp.Name": {
+            "type": "string",
+            "maxLength": 80,
+            "metadata": {
+                "description": "Name of the Logic App that will handle new Docker Hub webhooks"
+            }
+        },
+        "GitHub.Repo.Owner": {
+            "type": "string",
+            "defaultValue": "Azure",
+            "metadata": {
+                "description": "Name of the owner for the GitHub repo"
+            }
+        },
+        "GitHub.Repo.Name": {
+            "type": "string",
+            "defaultValue": "azure-k8s-metrics-adapter",
+            "metadata": {
+                "description": "Name of the GitHub repo"
+            }
+        },
+        "GitHub.Bot.Name": {
+            "type": "string",
+            "defaultValue": "azure-bot",
+            "metadata": {
+                "description": "Name of the GitHub account that will act as a bot"
+            }
+        },
+        "GitHub.Bot.Password": {
+            "type": "securestring",
+            "metadata": {
+                "description": "Password to authenticate with for the GitHub account that will act as a bot"
+            }
+        }
+    },
+    "variables": {
+        "Alerts.ActionGroup.Name": "Promitor - Maintainers"
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Logic/workflows",
+            "apiVersion": "2016-06-01",
+            "name": "[parameters('LogicApp.Name')]",
+            "location": "[resourceGroup().location]",
+            "properties": {
+                "definition": {
+                    "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+                    "actions": {
+                        "Define_GitHub_comment_text": {
+                            "inputs": "Docker image for this PR was built and is available on [Docker Hub](@{triggerBody()?['repository']?['repo_url']}).\n\nYou can pull it locally via the CLI:\n```shell\ndocker pull @{triggerBody()?['repository']?['repo_name']}:@{triggerBody()?['push_data']?['tag']}\n```",
+                            "runAfter": {
+                                "Determine_GitHub_Issue_Id": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "Compose"
+                        },
+                        "Determine_GitHub_Issue_Id": {
+                            "inputs": "@replace(toLower(triggerBody()?['push_data']?['tag']), 'pr', '')",
+                            "runAfter": {},
+                            "type": "Compose"
+                        },
+                        "HTTP": {
+                            "inputs": {
+                                "authentication": {
+                                    "password": "[parameters('GitHub.Bot.Password')]",
+                                    "type": "Basic",
+                                    "username": "[parameters('GitHub.Bot.Name')]"
+                                },
+                                "body": {
+                                    "body": "@{outputs('Define_GitHub_comment_text')}"
+                                },
+                                "method": "POST",
+                                "uri": "@{concat('https://api.github.com/repos/', parameters('GitHub.Repo.Owner'),'/', parameters('GitHub.Repo.Name'),'/issues/', outputs('Determine_GitHub_Issue_Id'),'/comments')}"
+                            },
+                            "runAfter": {
+                                "Define_GitHub_comment_text": [
+                                    "Succeeded"
+                                ]
+                            },
+                            "type": "Http"
+                        }
+                    },
+                    "contentVersion": "1.0.0.0",
+                    "outputs": {},
+                    "parameters": {
+                        "GitHub.Repo.Owner": {
+                            "defaultValue": "[parameters('GitHub.Repo.Owner')]",
+                            "type": "string"
+                        },
+                        "GitHub.Repo.Name": {
+                            "defaultValue": "[parameters('GitHub.Repo.Name')]",
+                            "type": "string"
+                        }
+                    },
+                    "triggers": {
+                        "manual": {
+                            "inputs": {
+                                "schema": {
+                                    "properties": {
+                                        "callback_url": {
+                                            "type": "string"
+                                        },
+                                        "push_data": {
+                                            "properties": {
+                                                "images": {
+                                                    "type": "array"
+                                                },
+                                                "pushed_at": {
+                                                    "type": "integer"
+                                                },
+                                                "pusher": {
+                                                    "type": "string"
+                                                },
+                                                "tag": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "repository": {
+                                            "properties": {
+                                                "comment_count": {
+                                                    "type": "integer"
+                                                },
+                                                "date_created": {
+                                                    "type": "integer"
+                                                },
+                                                "description": {
+                                                    "type": "string"
+                                                },
+                                                "full_description": {
+                                                    "type": "string"
+                                                },
+                                                "is_official": {
+                                                    "type": "boolean"
+                                                },
+                                                "is_private": {
+                                                    "type": "boolean"
+                                                },
+                                                "is_trusted": {
+                                                    "type": "boolean"
+                                                },
+                                                "name": {
+                                                    "type": "string"
+                                                },
+                                                "namespace": {
+                                                    "type": "string"
+                                                },
+                                                "owner": {
+                                                    "type": "string"
+                                                },
+                                                "repo_name": {
+                                                    "type": "string"
+                                                },
+                                                "repo_url": {
+                                                    "type": "string"
+                                                },
+                                                "star_count": {
+                                                    "type": "integer"
+                                                },
+                                                "status": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            },
+                            "kind": "Http",
+                            "type": "Request"
+                        }
+                    }
+                },
+                "parameters": {}
+            },
+            "dependsOn": []
+        },
+        {
+            "type": "Microsoft.Insights/actionGroups",
+            "apiVersion": "2018-03-01",
+            "name": "[variables('Alerts.ActionGroup.Name')]",
+            "location": "Global",
+            "properties": {
+                "groupShortName": "AlertHandler",
+                "enabled": true,
+                "smsReceivers": [],
+                "emailReceivers": [
+                    {
+                        "name": "Tom Kerkhove",
+                        "emailAddress": "kerkhove.tom@gmail.com"
+                    }
+                ],
+                "webhookReceivers": []
+            }
+        },
+        {
+            "name": "Scraper CI Bot - Docker Hub Integration Run Failed",
+            "type": "Microsoft.Insights/metricAlerts",
+            "location": "global",
+            "apiVersion": "2018-03-01",
+            "tags": {},
+            "properties": {
+                "description": "Scraper CI Bot - Docker Hub integration failed to run and post a comment on the pull request in GitHub",
+                "severity": 3,
+                "enabled": true,
+                "scopes": [
+                    "[resourceId('Microsoft.Logic/workflows', parameters('LogicApp.Name'))]"
+                ],
+                "evaluationFrequency": "PT5M",
+                "windowSize": "PT5M",
+                "criteria": {
+                    "odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria",
+                    "allOf": [
+                        {
+                            "name": "1st criterion",
+                            "metricName": "RunsFailed",
+                            "dimensions": [],
+                            "operator": "GreaterThanOrEqual",
+                            "threshold": "1",
+                            "timeAggregation": "Total"
+                        }
+                    ]
+                },
+                "actions": [
+                    {
+                        "actionGroupId": "[resourceId('Microsoft.Insights/actionGroups', variables('Alerts.ActionGroup.Name'))]"
+                    }
+                ]
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.Insights/actionGroups', variables('Alerts.ActionGroup.Name'))]",
+                "[resourceId('Microsoft.Logic/workflows', parameters('LogicApp.Name'))]"
+            ]
+        },
+        {
+            "name": "Scraper CI Bot - Docker Hub Integration Trigger Failed",
+            "type": "Microsoft.Insights/metricAlerts",
+            "location": "global",
+            "apiVersion": "2018-03-01",
+            "tags": {},
+            "properties": {
+                "description": "Scraper CI Bot - Docker Hub integration failed to be triggered due to an issue",
+                "severity": 3,
+                "enabled": true,
+                "scopes": [
+                    "[resourceId('Microsoft.Logic/workflows', parameters('LogicApp.Name'))]"
+                ],
+                "evaluationFrequency": "PT5M",
+                "windowSize": "PT5M",
+                "criteria": {
+                    "odata.type": "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria",
+                    "allOf": [
+                        {
+                            "name": "1st criterion",
+                            "metricName": "TriggersFailed",
+                            "dimensions": [],
+                            "operator": "GreaterThanOrEqual",
+                            "threshold": "1",
+                            "timeAggregation": "Total"
+                        }
+                    ]
+                },
+                "actions": [
+                    {
+                        "actionGroupId": "[resourceId('Microsoft.Insights/actionGroups', variables('Alerts.ActionGroup.Name'))]"
+                    }
+                ]
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.Insights/actionGroups', variables('Alerts.ActionGroup.Name'))]",
+                "[resourceId('Microsoft.Logic/workflows', parameters('LogicApp.Name'))]"
+            ]
+        }
+    ]
+}

--- a/deploy/bots/docker-hub/azuredeploy.parameters.json
+++ b/deploy/bots/docker-hub/azuredeploy.parameters.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "LogicApp.Name": {
+            "value": "#{LogicApp.Name}#"
+        },
+        "GitHub.Repo.Owner": {
+            "value": "#{GitHub.Repo.Owner}#"
+        },
+        "GitHub.Repo.Name": {
+            "value": "#{GitHub.Repo.Name}#"
+        },
+        "GitHub.Bot.Name": {
+            "value": "#{GitHub.Bot.Name}#"
+        },
+        "GitHub.Bot.Password": {
+            "value": "#{GitHub.Bot.Password}#"
+        }
+    }
+}


### PR DESCRIPTION
Provide Docker Hub bot to post PR updates when a new Docker image has been pushed.

It's based on the one I'm using for Promitor but reduced it to the following:
![image](https://user-images.githubusercontent.com/4345663/55050417-d03d8380-500d-11e9-9735-88a71f57b5e2.png)

Docker image name + tag are done on the fly so should match your ones.
I've granted the bot access to the repo but actually, that shouldn't be a requirement unless the repo is private.